### PR TITLE
Need to call create_makefile("pdf417/pdf417") on Ruby 2.7.7 / Bundler 2.4.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+AllCops:
+  NewCops: enable
+
+Metrics:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,16 @@
+# frozen_string_literal: true
+
 # A sample Gemfile
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 group :test do
-  gem 'shoulda', :require => false
+  gem 'shoulda', require: false
 end
 
-
 gemspec
+
+# Dev dependencies
+gem 'bundler', '~> 2.5'
+gem 'minitest', '~> 5.0'
+gem 'ostruct', '~> 0.6.0'
+gem 'rake', '~> 13'

--- a/Rakefile
+++ b/Rakefile
@@ -1,20 +1,21 @@
-require "bundler/gem_tasks"
-require "rake/testtask"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << "test"
-  t.libs << "lib"
+  t.libs << 'test'
+  t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
 end
 
-task :default => :test
+task default: :test
 
 desc 'rebuilds the pdf417 library'
 task :build_extension do
-  pwd = `pwd`
-  system "cd ext/pdf417 && make clean"
-  system "cd ext/pdf417 && ruby extconf.rb && make"
+  `pwd`
+  system 'cd ext/pdf417 && make clean'
+  system 'cd ext/pdf417 && ruby extconf.rb && make'
 end
 
-
-task :test => [:build_extension]
+task test: [:build_extension]

--- a/ext/pdf417/extconf.rb
+++ b/ext/pdf417/extconf.rb
@@ -1,4 +1,4 @@
 require 'mkmf'
 extension_name = 'pdf417'
 dir_config(extension_name)
-create_makefile(extension_name)
+create_makefile("#{extension_name}/#{extension_name}")

--- a/ext/pdf417/extconf.rb
+++ b/ext/pdf417/extconf.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'mkmf'
 extension_name = 'pdf417'
 dir_config(extension_name)

--- a/lib/pdf417.rb
+++ b/lib/pdf417.rb
@@ -1,118 +1,112 @@
+# frozen_string_literal: true
+
 require 'pdf417/pdf417'
 require 'pdf417/lib'
 
+# A wrapper for the pdf417lib C Library,
 class PDF417
-  
   class GenerationError < StandardError; end
-  
+
   class << self
     def encode_text(text)
       PDF417::Lib.encode_text(text)
-    end    
+    end
   end
 
   attr_reader :bit_columns, :bit_rows, :bit_length
-  
+
   def initialize(*attrs)
-    # TODO:  Test these defaults, make sure that they can get set on init, check to see that the output changes accordingly
-    self.text = ""
+    # TODO:  Test these defaults, make sure that they can get set on init, and the output changes accordingly
+    self.text = ''
     @y_height = 3
     @aspect_ratio = 0.5
     @rows = nil
     @cols = nil
-    
+
     if attrs.first.is_a?(String)
       self.text = attrs.first
-    elsif attrs.first.is_a?(Hash)      
-      attrs.first.each do |k,v|
-        if self.respond_to?("#{k}=".to_sym)
-          self.send("#{k}=".to_sym, v)
-        end
+    elsif attrs.first.is_a?(Hash)
+      attrs.first.each do |k, v|
+        send(:"#{k}=", v) if respond_to?(:"#{k}=")
       end
     end
 
     @blob = nil
   end
-  
+
   def inspect
-    "#<#{self.class.name}:#{self.object_id} >"
+    "#<#{self.class.name}:#{object_id} >"
   end
-  
-  
+
   def text=(val)
     @codewords = @blob = nil
     @text = val
   end
-  
+
   def text
     if @raw_codewords.nil?
       @text
     else
-      ""
+      ''
     end
   end
-  
+
   def codewords
-    return @raw_codewords if !@raw_codewords.nil?
+    return @raw_codewords unless @raw_codewords.nil?
+
     @codewords ||= self.class.encode_text(text)
   end
-          
+
   # Y Height
-  def y_height
-    @y_height
-  end
+  attr_reader :y_height
+
   def y_height=(val)
     @blob = nil
     @y_height = val
   end
-    
+
   # Aspect ratio
-  def aspect_ratio
-    @aspect_ratio
-  end
+  attr_reader :aspect_ratio
+
   def aspect_ratio=(val)
     @blob = nil
     @rows = nil
     @cols = nil
     @aspect_ratio = val
   end
-    
+
   # For setting the codewords directly
-  def raw_codewords
-    @raw_codewords
-  end
+  attr_reader :raw_codewords
+
   def raw_codewords=(val)
     @blob = nil
     @raw_codewords = val
   end
-    
+
   # Make the barcode at least this number of rows
-  def rows
-    @rows
-  end
+  attr_reader :rows
+
   def rows=(val)
     @blob = nil
     @rows = val
   end
-    
+
   # Make the barcode at least this number of columns
-  def cols
-    @cols
-  end
+  attr_reader :cols
+
   def cols=(val)
     @blob = nil
     @cols = val
   end
-    
+
   # Request the specified error level must be between 0 and 8
-  def error_level
-    @error_level
-  end
+  attr_reader :error_level
+
   def error_level=(val)
     @blob = nil
     @error_level = val
   end
-      
+
   def generate!
     lib = Lib.new(text)
     options = []
@@ -123,106 +117,109 @@ class PDF417
       lib.generation_options |= Lib::PDF417_USE_RAW_CODEWORDS
       options << 'raw codewords'
     end
-    
-    if self.rows.to_i > 0 && self.cols.to_i > 0
-      lib.code_rows = self.rows.to_i
-      lib.code_cols = self.cols.to_i
+
+    if rows.to_i.positive? && cols.to_i.positive?
+      lib.code_rows = rows.to_i
+      lib.code_cols = cols.to_i
       lib.generation_options |= Lib::PDF417_FIXED_RECTANGLE
       options << "#{rows}x#{cols}"
-    elsif self.rows.to_i > 0
-      lib.code_rows = self.rows.to_i 
+    elsif rows.to_i.positive?
+      lib.code_rows = rows.to_i
       lib.generation_options |= Lib::PDF417_FIXED_ROWS
       options << "#{rows} rows"
-    elsif self.cols.to_i > 0
-      lib.code_cols = self.cols.to_i
+    elsif cols.to_i.positive?
+      lib.code_cols = cols.to_i
       lib.generation_options |= Lib::PDF417_FIXED_COLUMNS
       options << "#{cols} cols"
     end
-  
-    if self.error_level.to_i >= 0 && self.error_level.to_i <= 8
-      lib.error_level = self.error_level.to_i
+
+    if error_level.to_i >= 0 && error_level.to_i <= 8
+      lib.error_level = error_level.to_i
       lib.generation_options |= Lib::PDF417_USE_ERROR_LEVEL
       options << "requested #{error_level.to_i} error level"
     end
-  
-    lib.aspect_ratio = self.aspect_ratio.to_f
-    lib.y_height = self.y_height.to_f
-  
-    (@blob = lib.to_blob) 
+
+    lib.aspect_ratio = aspect_ratio.to_f
+    lib.y_height = y_height.to_f
+
+    (@blob = lib.to_blob)
     if @blob.nil? || @blob.empty?
       if lib.generation_error == Lib::PDF417_ERROR_TEXT_TOO_BIG
-        raise GenerationError, "Text is too big"
+        raise GenerationError, 'Text is too big'
       elsif lib.generation_error == Lib::PDF417_ERROR_INVALID_PARAMS
         msg = "Invalid parameters: #{options.join(', ')}"
-        if lib.generation_options & Lib::PDF417_USE_RAW_CODEWORDS && lib.raw_codewords.length != lib.raw_codewords.first
-          msg +=".  The first element of the raw codwords must be the length of the array.  Currently it is #{lib.raw_codewords.first}, perhaps it should be #{lib.raw_codewords.length}?"
+        if (lib.generation_options &
+            Lib::PDF417_USE_RAW_CODEWORDS) && lib.raw_codewords.length != lib.raw_codewords.first
+          msg += '.  The first element of the raw codwords must be the length of the array.  ' \
+                 "Currently it is #{lib.raw_codewords.first}, perhaps it should be #{lib.raw_codewords.length}?"
         end
         raise GenerationError, msg
       else
         raise GenerationError, "Could not generate bitmap error: #{options.join(', ')}"
       end
     else
-      if lib.raw_codewords.is_a?(Array)
-        @codewords = lib.raw_codewords
-      else
-        @codewords = lib.codewords
-      end
+      @codewords = if lib.raw_codewords.is_a?(Array)
+                     lib.raw_codewords
+                   else
+                     lib.codewords
+                   end
       @bit_columns = lib.bit_columns
       @bit_rows = ((lib.bit_columns - 1) / 8) + 1
       @bit_length = lib.bit_length
-      @rows = lib.code_rows 
+      @rows = lib.code_rows
       @cols = lib.code_cols
       @error_level = lib.error_level
       @aspect_ratio = lib.aspect_ratio
       @y_height = lib.y_height
-      return true
+      true
     end
   end
-    
-  
+
   def to_blob
-    self.generate! if @blob.nil?
-    @blob    
-  end      
-  alias_method :blob, :to_blob
-  
+    generate! if @blob.nil?
+    @blob
+  end
+  alias blob to_blob
+
   def encoding
-    self.generate! if @blob.nil?
-    
+    generate! if @blob.nil?
+
     # This matches the output from the pdf417 lib sample output.
-    enc = self.blob.bytes.to_a.each_slice(self.bit_rows).to_a[0..(self.rows-1)] # sometimes we get more rows than expected, truncate
-    
-    # The length returned here is too long and we have extra data that gets padded w/ zeroes, meaning it doesn't all match.
+    enc = blob.bytes.to_a.each_slice(bit_rows).to_a[0..(rows - 1)] # sometimes we get more rows than expected, truncate
+
+    # The length returned here is too long and we have extra data that gets padded w/ zeroes,
+    # meaning it doesn't all match.
     # Eg, instead of ending with "111111101000101001" it ends with "1111111010001010010000000".
-    return enc.collect do |row_of_bytes|
-      row_of_bytes.collect{|x| sprintf("%08b", x)}.join[0..self.bit_columns-1]
+    enc.collect do |row_of_bytes|
+      row_of_bytes.collect { |x| format('%08b', x) }.join[0..bit_columns - 1]
     end
   end
-  
+
   def encoding_to_s
-    self.encoding.each{|x| puts x.gsub("0"," ")}
+    encoding.each { |x| puts x.gsub('0', ' ') }
   end
-  
+
   def to_chunky_png(opts = {})
     require 'chunky_png' unless defined?(ChunkyPNG)
-    
-    self.generate! if @blob.nil?
+
+    generate! if @blob.nil?
     opts[:x_scale] ||= 1
     opts[:y_scale] ||= 3
     opts[:margin] ||= 10
-    full_width = (self.bit_columns * opts[:x_scale]) + (opts[:margin] * 2)
-    full_height = (self.rows * opts[:y_scale]) + (opts[:margin] * 2)
-    
+    full_width = (bit_columns * opts[:x_scale]) + (opts[:margin] * 2)
+    full_height = (rows * opts[:y_scale]) + (opts[:margin] * 2)
+
     canvas = ChunkyPNG::Image.new(full_width, full_height, ChunkyPNG::Color::WHITE)
 
-    x, y = opts[:margin], opts[:margin]
-    booleans = encoding.map{|l| l.split(//).map{|c| c == '1' } }
+    x = opts[:margin]
+    y = opts[:margin]
+    booleans = encoding.map { |l| l.chars.map { |c| c == '1' } }
     booleans.each do |line|
       line.each do |bar|
         if bar
-          x.upto(x+(opts[:x_scale]-1)) do |xx|
-            y.upto y+(opts[:y_scale]-1) do |yy|
-              canvas[xx,yy] = ChunkyPNG::Color::BLACK
+          x.upto(x + (opts[:x_scale] - 1)) do |xx|
+            y.upto y + (opts[:y_scale] - 1) do |yy|
+              canvas[xx, yy] = ChunkyPNG::Color::BLACK
             end
           end
         end
@@ -237,6 +234,4 @@ class PDF417
   def to_png(opts = {})
     to_chunky_png(opts).to_datastream.to_s
   end
-    
-  
 end

--- a/lib/pdf417/lib.rb
+++ b/lib/pdf417/lib.rb
@@ -1,54 +1,60 @@
+# frozen_string_literal: true
+
 require 'pdf417/pdf417'
 
 # A barebones ruby interface to the C library, uses C style constants
 # and mixes in attribute accessors for moving data back and forth
-class PDF417::Lib
-  
-  PDF417_USE_ASPECT_RATIO = 0
-  PDF417_FIXED_RECTANGLE = 1
-  PDF417_FIXED_COLUMNS = 2
-  PDF417_FIXED_ROWS = 4
-  PDF417_AUTO_ERROR_LEVEL = 0
-  PDF417_USE_ERROR_LEVEL = 16
-  PDF417_USE_RAW_CODEWORDS = 64
-  PDF417_INVERT_BITMAP = 128
+class PDF417
+  # Main library functions of PDF417
+  class Lib
+    PDF417_USE_ASPECT_RATIO = 0
+    PDF417_FIXED_RECTANGLE = 1
+    PDF417_FIXED_COLUMNS = 2
+    PDF417_FIXED_ROWS = 4
+    PDF417_AUTO_ERROR_LEVEL = 0
+    PDF417_USE_ERROR_LEVEL = 16
+    PDF417_USE_RAW_CODEWORDS = 64
+    PDF417_INVERT_BITMAP = 128
 
-  PDF417_ERROR_SUCCESS = 0
-  PDF417_ERROR_TEXT_TOO_BIG = 1
-  PDF417_ERROR_INVALID_PARAMS = 2
-  
-  # The int representing the options used to generate the barcode, defined in the library as:
-  # [PDF417_USE_ASPECT_RATIO] use aspectRatio to set the y/x dimension. Also uses yHeight
-  # [PDF417_FIXED_RECTANGLE] make the barcode dimensions at least codeColumns by codeRows
-  # [PDF417_FIXED_COLUMNS] make the barcode dimensions at least codeColumns
-  # [PDF417_FIXED_ROWS] make the barcode dimensions at least codeRows
-  # [PDF417_AUTO_ERROR_LEVEL] automatic error level depending on text size
-  # [PDF417_USE_ERROR_LEVEL] the error level is errorLevel. The used errorLevel may be different
-  # [PDF417_USE_RAW_CODEWORDS] use codewords instead of text
-  # [PDF417_INVERT_BITMAP] invert the resulting bitmap
-  #
-  # For example
-  #   b.generation_options = PDF417::PDF417_INVERT_BITMAP | PDF417::PDF417_AUTO_ERROR_LEVEL
-  
-  attr_accessor :generation_options, :text, :raw_codewords
-  # The following are read from the last generated barcode, but they need a writer because they get set
-  attr_writer :code_rows, :code_cols, :error_level, :y_height, :aspect_ratio
-  def inspect # :nodoc:
-    attributes = inspect_attributes.reject { |x|
-      begin
+    PDF417_ERROR_SUCCESS = 0
+    PDF417_ERROR_TEXT_TOO_BIG = 1
+    PDF417_ERROR_INVALID_PARAMS = 2
+
+    # The int representing the options used to generate the barcode, defined in the library as:
+    # [PDF417_USE_ASPECT_RATIO] use aspectRatio to set the y/x dimension. Also uses yHeight
+    # [PDF417_FIXED_RECTANGLE] make the barcode dimensions at least codeColumns by codeRows
+    # [PDF417_FIXED_COLUMNS] make the barcode dimensions at least codeColumns
+    # [PDF417_FIXED_ROWS] make the barcode dimensions at least codeRows
+    # [PDF417_AUTO_ERROR_LEVEL] automatic error level depending on text size
+    # [PDF417_USE_ERROR_LEVEL] the error level is errorLevel. The used errorLevel may be different
+    # [PDF417_USE_RAW_CODEWORDS] use codewords instead of text
+    # [PDF417_INVERT_BITMAP] invert the resulting bitmap
+    #
+    # For example
+    #   b.generation_options = PDF417::PDF417_INVERT_BITMAP | PDF417::PDF417_AUTO_ERROR_LEVEL
+
+    attr_accessor :generation_options, :text, :raw_codewords
+    # The following are read from the last generated barcode, but they need a writer because they get set
+    attr_writer :code_rows, :code_cols, :error_level, :y_height, :aspect_ratio
+
+    def inspect # :nodoc:
+      attributes = inspect_attributes.reject do |x|
         attribute = send x
         !attribute || (attribute.respond_to?(:empty?) && attribute.empty?)
       rescue NoMethodError
         true
       end
-    }.map { |attribute|
-      "#{attribute.to_s}=#{send(attribute).inspect}"
-    }.join ' '
-    "#<#{self.class.name}:#{sprintf("0x%x", object_id)} #{attributes}>"
-  end  
-  
-  private
-  def inspect_attributes
-    [:text, :bit_columns, :bit_length, :code_rows, :code_columns, :codeword_length, :error_level, :generation_options, :aspect_ratio, :y_height, :generation_error]
+      attributes = attributes.map do |attribute|
+        "#{attribute}=#{send(attribute).inspect}"
+      end
+      "#<#{self.class.name}:#{format('0x%x', object_id)} #{attributes.join(' ')}>"
+    end
+
+    private
+
+    def inspect_attributes
+      %i[text bit_columns bit_length code_rows code_columns codeword_length error_level generation_options
+         aspect_ratio y_height generation_error]
+    end
   end
 end

--- a/lib/pdf417/version.rb
+++ b/lib/pdf417/version.rb
@@ -1,3 +1,5 @@
-module PDF417
-  VERSION = "1.0.1"
+# frozen_string_literal: true
+
+class PDF417
+  VERSION = '1.0.1'
 end

--- a/pdf417.gemspec
+++ b/pdf417.gemspec
@@ -1,47 +1,30 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'pdf417/version'
 
 Gem::Specification.new do |s|
-  s.name = %q{pdf417}
+  s.name = 'pdf417'
   s.version = PDF417::VERSION
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["jamesprior"]
-  s.date = %q{2011-07-25}
-  s.description = %q{Generate a series of codewords or a binary blob for PDF417 barcodes}
-  s.email = %q{j.prior@asee.org}
-  s.extensions = ["ext/pdf417/extconf.rb"]
+  s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
+  s.authors = ['jamesprior']
+  s.description = 'Generate a series of codewords or a binary blob for PDF417 barcodes'
+  s.email = 'j.prior@asee.org'
+  s.extensions = ['ext/pdf417/extconf.rb']
   s.extra_rdoc_files = [
-    "LICENSE",
-     "README.rdoc"
+    'LICENSE',
+    'README.rdoc'
   ]
-  s.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  # s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  s.files = `git ls-files -z`.split("\x0").grep_v(%r{^(test|spec|features)/})
 
-  s.homepage = %q{http://github.com/asee/pdf417}
-  s.rdoc_options = ["--charset=UTF-8"]
-  s.require_paths = ["lib", "ext"]
-  s.rubygems_version = %q{1.5.3}
-  s.summary = %q{A Ruby wrapper for the PDF417 barcode library}
-  s.test_files = [
-    "test/pdf417/lib_test.rb",
-     "test/pdf417_test.rb",
-     "test/test_helper.rb"
-  ]
+  s.homepage = 'http://github.com/asee/pdf417'
+  s.rdoc_options = ['--charset=UTF-8']
+  s.require_paths = %w[lib ext]
+  s.required_ruby_version = '>= 3.0'
+  s.summary = 'A Ruby wrapper for the PDF417 barcode library'
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-    else
-    end
-  else
-  end
-  
-  s.add_development_dependency "bundler", "~> 1.11"
-  s.add_development_dependency "rake", "~> 10.0"
-  s.add_development_dependency "minitest", "~> 5.0"
-  
+  s.metadata['rubygems_mfa_required'] = 'true'
 end
-

--- a/script/console
+++ b/script/console
@@ -1,10 +1,12 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 irb = RUBY_PLATFORM =~ /(:?mswin|mingw)/ ? 'irb.bat' : 'irb'
-libs =  " -r irb/completion"
+libs =  ' -r irb/completion'
 libs << " -I #{File.join(File.dirname(__FILE__), '..', 'lib')}"
 libs << " -I #{File.join(File.dirname(__FILE__), '..', 'ext')}"
 libs << " -I #{File.join(File.dirname(__FILE__), '..', '..', 'barby')}"
-libs << " -r pdf417"
-libs << " -r rubygems"
-#libs << " -r chunky_png"
+libs << ' -r pdf417'
+libs << ' -r rubygems'
+# libs << " -r chunky_png"
 exec "#{irb} #{libs} --simple-prompt"

--- a/test/pdf417/lib_test.rb
+++ b/test/pdf417/lib_test.rb
@@ -1,72 +1,76 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
-class PDF417::Lib::LibTest <  Minitest::Test
+class PDF417
+  class Lib
+    class LibTest < Minitest::Test
+      should 'not fail init with empty text' do
+        assert PDF417::Lib.new(text: '')
+      end
 
-  should "not fail init with empty text" do
-    assert PDF417::Lib.new(text: '')
-  end
-  
-  should "initialize text" do
-    b = PDF417::Lib.new("fred")
-    assert_equal "fred", b.text
-  end
-  
-  should "initialize generation_options" do
-    b = PDF417::Lib.new("fred")
-    assert_equal 0, b.generation_options
-  end
-  
-  should "know the right codewords for fred" do
-    assert_equal [4, 815, 514, 119], PDF417::Lib.encode_text("fred")
-    assert_equal [4, 815, 514, 119], PDF417::Lib.new("fred").codewords
-  end
-  
-  should "re-generate if the text has been reassigned" do
-    b = PDF417::Lib.new("fred")
-    fred_words = b.codewords
-    fred_blob = b.to_blob
-    b.text = "Joebob"
-    assert fred_words != b.codewords
-    assert fred_blob != b.to_blob
-  end
-  
-  should "re-generate if the text has been updated" do
-    b = PDF417::Lib.new("fred")
-    fred_words = b.codewords
-    fred_blob = b.to_blob
-    b.text += " and joe"
-    assert fred_words != b.codewords
-    assert fred_blob != b.to_blob    
-  end
-  
-  should "re-generate if the options have changed" do
-    b = PDF417::Lib.new("fred")
-    fred_words = b.codewords
-    fred_blob = b.to_blob
-    b.generation_options = PDF417::Lib::PDF417_INVERT_BITMAP
-    assert_equal b.generation_options, PDF417::Lib::PDF417_INVERT_BITMAP
-    assert_equal fred_words, b.codewords # NOTE that the codewords have not changed, just the binary blob
-    assert fred_blob != b.to_blob    
-  end
-  
-  should "work when generation options are set weird" do
-    b = PDF417::Lib.new("fred")
-    b.generation_options = "ALBERT"
-    assert b.codewords.is_a?(Array)
-  end
-  
-  should "encode a complete ruby string with null bytes" do
-    data_without_null_byptes = ['01', '01']
-    without_null_bytes = PDF417::Lib.encode_text([data_without_null_byptes.join].pack("H*"))
+      should 'initialize text' do
+        b = PDF417::Lib.new('fred')
+        assert_equal 'fred', b.text
+      end
 
-    data_with_null_byptes = ['01', '01', '00', '00', '00', '00']
-    with_null_bytes = PDF417::Lib.encode_text([data_with_null_byptes.join].pack("H*"))
-    
-    refute_equal with_null_bytes, without_null_bytes
+      should 'initialize generation_options' do
+        b = PDF417::Lib.new('fred')
+        assert_equal 0, b.generation_options
+      end
+
+      should 'know the right codewords for fred' do
+        assert_equal [4, 815, 514, 119], PDF417::Lib.encode_text('fred')
+        assert_equal [4, 815, 514, 119], PDF417::Lib.new('fred').codewords
+      end
+
+      should 're-generate if the text has been reassigned' do
+        b = PDF417::Lib.new('fred')
+        fred_words = b.codewords
+        fred_blob = b.to_blob
+        b.text = 'Joebob'
+        assert fred_words != b.codewords
+        assert fred_blob != b.to_blob
+      end
+
+      should 're-generate if the text has been updated' do
+        b = PDF417::Lib.new('fred')
+        fred_words = b.codewords
+        fred_blob = b.to_blob
+        b.text += ' and joe'
+        assert fred_words != b.codewords
+        assert fred_blob != b.to_blob
+      end
+
+      should 're-generate if the options have changed' do
+        b = PDF417::Lib.new('fred')
+        fred_words = b.codewords
+        fred_blob = b.to_blob
+        b.generation_options = PDF417::Lib::PDF417_INVERT_BITMAP
+        assert_equal b.generation_options, PDF417::Lib::PDF417_INVERT_BITMAP
+        assert_equal fred_words, b.codewords # NOTE: that the codewords have not changed, just the binary blob
+        assert fred_blob != b.to_blob
+      end
+
+      should 'work when generation options are set weird' do
+        b = PDF417::Lib.new('fred')
+        b.generation_options = 'ALBERT'
+        assert b.codewords.is_a?(Array)
+      end
+
+      should 'encode a complete ruby string with null bytes' do
+        data_without_null_byptes = %w[01 01]
+        without_null_bytes = PDF417::Lib.encode_text([data_without_null_byptes.join].pack('H*'))
+
+        data_with_null_byptes = %w[01 01 00 00 00 00]
+        with_null_bytes = PDF417::Lib.encode_text([data_with_null_byptes.join].pack('H*'))
+
+        refute_equal with_null_bytes, without_null_bytes
+      end
+
+      should 'not fail encode_text with empty text' do
+        assert_equal [], PDF417::Lib.encode_text('')
+      end
+    end
   end
-  
-  should "not fail encode_text with empty text" do
-    assert_equal [], PDF417::Lib.encode_text("")
-  end  
-  
 end

--- a/test/pdf417_test.rb
+++ b/test/pdf417_test.rb
@@ -1,200 +1,201 @@
+# frozen_string_literal: true
+
 begin
-  require "RMagick"
-rescue LoadError
+  require 'RMagick'
+rescue LoadError # rubocop:disable Lint/SuppressedException
 end
 
 require 'test_helper'
 
-class Pdf417Test <  Minitest::Test
-  
-  should "initialize text as an attr" do
-    b = PDF417.new(:text => "fred")
-    assert_equal "fred", b.text
-  end
-  
-  should "initialize text as a single parameter" do
-    b = PDF417.new("fred")
-    assert_equal "fred", b.text
+class Pdf417Test < Minitest::Test
+  should 'initialize text as an attr' do
+    b = PDF417.new(text: 'fred')
+    assert_equal 'fred', b.text
   end
 
-  should "defaults rows and cols to nil" do
-    b = PDF417.new("fred")
+  should 'initialize text as a single parameter' do
+    b = PDF417.new('fred')
+    assert_equal 'fred', b.text
+  end
+
+  should 'defaults rows and cols to nil' do
+    b = PDF417.new('fred')
     assert_nil b.rows
     assert_nil b.cols
   end
 
-  should "allows fixed cols" do
-    b = PDF417.new(text: "01234"*60, error_level: 6, cols: 5)
+  should 'allows fixed cols' do
+    b = PDF417.new(text: '01234' * 60, error_level: 6, cols: 5)
     b.to_blob
     assert_equal [5, 47], [b.cols, b.rows]
 
     # if it's too small, auto determine the best value
-    b = PDF417.new(text: "01234"*60, error_level: 6, cols: 1)
+    b = PDF417.new(text: '01234' * 60, error_level: 6, cols: 1)
     b.to_blob
     assert_equal [3, 90], [b.cols, b.rows]
 
     # if it's too big, auto determine the best value
-    b = PDF417.new(text: "01234"*60, error_level: 6, cols: 100)
+    b = PDF417.new(text: '01234' * 60, error_level: 6, cols: 100)
     b.to_blob
     assert_equal [30, 8], [b.cols, b.rows]
   end
 
-  should "allows fixed rows" do
-    b = PDF417.new(text: "01234"*60, error_level: 6, rows: 10)
+  should 'allows fixed rows' do
+    b = PDF417.new(text: '01234' * 60, error_level: 6, rows: 10)
     b.to_blob
     assert_equal [24, 10], [b.cols, b.rows]
 
     # if it's too small, auto determine the best value
-    b = PDF417.new(text: "01234"*60, error_level: 6, rows: 6)
+    b = PDF417.new(text: '01234' * 60, error_level: 6, rows: 6)
     b.to_blob
     assert_equal [30, 8], [b.cols, b.rows]
 
     # if it's too big, auto determine the best value
-    b = PDF417.new(text: "01234"*60, error_level: 6, rows: 100)
+    b = PDF417.new(text: '01234' * 60, error_level: 6, rows: 100)
     b.to_blob
     assert_equal [3, 90], [b.cols, b.rows]
   end
 
-  should "let default aspect_ratio to define rows and cols" do
-    b = PDF417.new(text: "01234"*60, error_level: 6)
+  should 'let default aspect_ratio to define rows and cols' do
+    b = PDF417.new(text: '01234' * 60, error_level: 6)
     b.to_blob
     assert_equal 7, b.cols
     assert_equal 34, b.rows
   end
 
-  should "let custom aspect_ratio to define rows and cols" do
-    b = PDF417.new(text: "01234"*60, aspect_ratio: 0.618,
+  should 'let custom aspect_ratio to define rows and cols' do
+    b = PDF417.new(text: '01234' * 60, aspect_ratio: 0.618,
                    error_level: 6)
     b.to_blob
     assert_equal 6, b.cols
     assert_equal 39, b.rows
   end
 
-  should "know the right codewords for fred" do
-    assert_equal [4, 815, 514, 119], PDF417.encode_text("fred")
-    assert_equal [4, 815, 514, 119], PDF417.new(:text => "fred").codewords
+  should 'know the right codewords for fred' do
+    assert_equal [4, 815, 514, 119], PDF417.encode_text('fred')
+    assert_equal [4, 815, 514, 119], PDF417.new(text: 'fred').codewords
   end
-  
-  should "re-generate codewords if the text has been reassigned" do
-    b = PDF417.new("fred")
+
+  should 're-generate codewords if the text has been reassigned' do
+    b = PDF417.new('fred')
     fred_words = b.codewords
     fred_blob = b.to_blob
-    b.text = "Joebob"
+    b.text = 'Joebob'
     assert fred_words != b.codewords
     assert fred_blob != b.to_blob
   end
-  
-  should "re-generate if the text has been updated" do
-    b = PDF417.new("fred")
+
+  should 're-generate if the text has been updated' do
+    b = PDF417.new('fred')
     fred_words = b.codewords
     fred_blob = b.to_blob
-    b.text += " and joe"
+    b.text += ' and joe'
     assert fred_words != b.codewords
-    assert fred_blob != b.to_blob    
+    assert fred_blob != b.to_blob
   end
-  
-  should "re-generate if the options have changed" do
-    b = PDF417.new("fred")
+
+  should 're-generate if the options have changed' do
+    b = PDF417.new('fred')
     fred_words = b.codewords
     fred_blob = b.to_blob
     b.rows = b.rows + 4
-    assert_equal fred_words, b.codewords # NOTE that the codewords have not changed, just the binary blob
-    assert fred_blob != b.to_blob    
+    assert_equal fred_words, b.codewords # NOTE: that the codewords have not changed, just the binary blob
+    assert fred_blob != b.to_blob
   end
-  
-  should "set the text to nil when using raw codewords" do
-    b = PDF417.new("TEST") 
+
+  should 'set the text to nil when using raw codewords' do
+    b = PDF417.new('TEST')
     b.raw_codewords = [4, 815, 514, 119]
-    assert_equal "", b.text
+    assert_equal '', b.text
   end
-  
-  should "accept raw codewords" do
+
+  should 'accept raw codewords' do
     b = PDF417.new
     b.raw_codewords = [4, 815, 514, 119]
     assert_equal [4, 815, 514, 119], b.codewords
     begin
       b.to_blob
-    rescue Exception => e
+    rescue Exception => e # rubocop:disable Lint/RescueException
       assert false, "Expected nothing raised, instead got #{e.message}"
     end
     assert_barcode b
   end
-  
-  context "after generating" do
+
+  context 'after generating' do
     setup do
-      @barcode = PDF417.new("test")
+      @barcode = PDF417.new('test')
       @barcode.generate!
       @blob = @barcode.blob
     end
-    
-    should "have a blob" do
+
+    should 'have a blob' do
       refute_nil @barcode.blob
       refute_nil @barcode.to_blob
       assert_barcode @barcode
     end
-    
-    should "know bit columns" do
+
+    should 'know bit columns' do
       refute_nil @barcode.bit_columns
     end
-    
-    should "know bit rows" do
+
+    should 'know bit rows' do
       refute_nil @barcode.bit_rows
     end
-    
-    should "know bit length" do
+
+    should 'know bit length' do
       refute_nil @barcode.bit_length
     end
-    
-    should "know rows" do
+
+    should 'know rows' do
       refute_nil @barcode.rows
     end
-    
-    should "know cols" do
+
+    should 'know cols' do
       refute_nil @barcode.cols
     end
-    
-    should "know error level" do
+
+    should 'know error level' do
       refute_nil @barcode.error_level
     end
-    
-    should "know aspect ratio" do
+
+    should 'know aspect ratio' do
       refute_nil @barcode.aspect_ratio
     end
-    
-    should "know y height" do
+
+    should 'know y height' do
       refute_nil @barcode.y_height
     end
-    
-    should "regenerate after rows changed" do
+
+    should 'regenerate after rows changed' do
       @barcode.rows = 10
       refute_equal @blob, @barcode.to_blob
       assert_barcode @barcode
     end
-    
-    should "regenerate after cols changed" do
+
+    should 'regenerate after cols changed' do
       @barcode.cols = 10
       refute_equal @blob, @barcode.to_blob
       assert_barcode @barcode
     end
-    
-    should "regenerate after error level changed" do
+
+    should 'regenerate after error level changed' do
       @barcode.error_level = 7
       refute_equal @blob, @barcode.to_blob
       assert_barcode_start_sequence @barcode
       assert_barcode_end_sequence @barcode
     end
-    
-    should "regenerate after raw codewords changed" do
+
+    should 'regenerate after raw codewords changed' do
       @barcode.raw_codewords = @barcode.codewords + [245, 123]
       @barcode.raw_codewords[0] = @barcode.raw_codewords.length
       refute_equal @blob, @barcode.to_blob
       assert_barcode @barcode
     end
-        
-    should "regenerate after aspect ratio changed" do
-      # Aspect ratio does not apply when both rows and cols are set, so re-set our 
+
+    should 'regenerate after aspect ratio changed' do
+      # Aspect ratio does not apply when both rows and cols are set, so re-set our
       # reference and make sure there is enough data to have rows and cols
-      @barcode.text = "SOME REALLY LONG TEXT HERE! Gonna need some rows...." * 10
+      @barcode.text = 'SOME REALLY LONG TEXT HERE! Gonna need some rows....' * 10
       @barcode.rows = nil
       @barcode.cols = 10 # fixed cols input
       @barcode.error_level = 3
@@ -210,31 +211,27 @@ class Pdf417Test <  Minitest::Test
       assert_barcode_end_sequence @barcode
     end
   end
-  
-  should "know max rows after generating out of bounds" do
-    b = PDF417.new(:rows => 10000, :text => "test")
+
+  should 'know max rows after generating out of bounds' do
+    b = PDF417.new(rows: 10_000, text: 'test')
     b.generate!
-    refute_equal 10000, b.rows
+    refute_equal 10_000, b.rows
   end
-  
-  
+
   # if Object.const_defined? "Magick"
   #   context "using RMagick" do
   #     setup do
   #       @barcode = PDF417.new("test text" * 100)
   #       @barcode.generate!
   #     end
-  #     
+  #
   #     should "make an image" do
   #       # @barcode.to_blob.split(//).collect{|x| x.unpack("B*")}.to_s.inspect
   #       image = Magick::Image::from_blob(@barcode.to_blob).first
   #       puts "Width: #{image.columns}; Height: #{image.rows}"
   #     end
-  #   end      
+  #   end
   # else
   #   puts "*** Skipping rmagick tests"
   # end
-  
-  
-  
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,26 +1,29 @@
+# frozen_string_literal: true
 
 # $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 # $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'ext'))
 # $LOAD_PATH.unshift(File.dirname(__FILE__))
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-$LOAD_PATH.unshift File.expand_path('../../ext', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+$LOAD_PATH.unshift File.expand_path('../ext', __dir__)
 require 'pdf417'
 require 'minitest/autorun'
 require 'shoulda'
 
-
 def assert_barcode(barcode, msg = nil)
-  full_message = message(msg) { "Expected #{mu_pp(barcode)} to have a valid PDF417 start and end sequence for each row" }
-  assert (barcode.encoding.any? && barcode.encoding.all?{|x| x.start_with?("11111111010101000") && x.end_with?("111111101000101001") }), full_message
+  full_message = message(msg) do
+    "Expected #{mu_pp(barcode)} to have a valid PDF417 start and end sequence for each row"
+  end
+  assert (barcode.encoding.any? && barcode.encoding.all? do |x|
+            x.start_with?('11111111010101000') && x.end_with?('111111101000101001')
+          end), full_message
 end
 
 def assert_barcode_start_sequence(barcode, msg = nil)
   full_message = message(msg) { "Expected #{mu_pp(barcode)} to have a valid PDF417 start sequence for each row" }
-  assert (barcode.encoding.any? && barcode.encoding.all?{|x| x.start_with?("11111111010101000")}), full_message
+  assert (barcode.encoding.any? && barcode.encoding.all? { |x| x.start_with?('11111111010101000') }), full_message
 end
-
 
 def assert_barcode_end_sequence(barcode, msg = nil)
   full_message = message(msg) { "Expected #{mu_pp(barcode)} to have a valid PDF417 end sequence for each row" }
-  assert (barcode.encoding.any? && barcode.encoding.all?{|x| x.end_with?("111111101000101001") }), full_message
+  assert (barcode.encoding.any? && barcode.encoding.all? { |x| x.end_with?('111111101000101001') }), full_message
 end


### PR DESCRIPTION
Closes #11

Sorry I'm not exactly sure when or where this changed, but I started seeing this error message: `LoadError: cannot load such file -- pdf417/pdf417`.

This change fixes the issue